### PR TITLE
fix file_ass display bug

### DIFF
--- a/whisperx/utils.py
+++ b/whisperx/utils.py
@@ -193,7 +193,7 @@ def write_ass(transcript: Iterator[dict], file: TextIO,
         curr_words = [wrd['text'] for wrd in segment['word-level']]
         prev = segment['word-level'][0]['start']
         if prev is None:
-            prev = 0
+            prev = segment['start']
         for wdx, word in enumerate(segment['word-level']):
             if word['start'] is not None:
                 # fill gap between previous word


### PR DESCRIPTION
sentence start time on .ass files had a bug where if the first word did not have a timestamp, it would set sentence start_time to 0, but this needs to be the local 0 not actual file 0 (i.e. it should be segment['start'])